### PR TITLE
Switch server user ID to an integer, and player nick to Data.Text

### DIFF
--- a/src/Tronkell/Game/Types.hs
+++ b/src/Tronkell/Game/Types.hs
@@ -2,6 +2,7 @@ module Tronkell.Game.Types where
 
 import Control.Monad.State.Strict
 import Data.Map
+import qualified Data.Text as T
 
 import Tronkell.Types
 
@@ -20,7 +21,7 @@ data Game = Game { gameWinner  :: Maybe Player
 data GameStatus = InProgress | Finished
                   deriving (Eq, Enum, Show)
 
-newtype PlayerNick = PlayerNick { getPlayerNick :: String }
+newtype PlayerNick = PlayerNick { getPlayerNick :: T.Text }
                      deriving (Eq, Ord, Show)
 
 data Player = Player { playerNick        :: PlayerNick

--- a/src/Tronkell/Server/Server.hs
+++ b/src/Tronkell/Server/Server.hs
@@ -26,12 +26,13 @@ startServer :: Game.GameConfig -> IO ()
 startServer gConfig = withSocketsDo $ do
   sock         <- listenOn . PortNumber $ 4242
 
+  firstUId     <- newMVar $ UserID 0
   playersVar   <- newMVar M.empty
   serverChan   <- atomically newTChan
   clientsChan  <- newChan
   internalChan <- newChan
 
-  let server = Server gConfig playersVar sock serverChan clientsChan internalChan
+  let server = Server gConfig firstUId playersVar sock serverChan clientsChan internalChan
 
   forkIO $ handleIncomingMessages server Nothing >> return ()
 
@@ -49,9 +50,9 @@ mainLoop server@Server{..} = do
 runClient :: Handle -> Server -> IO ()
 runClient clientHdl server@Server{..} = do
   hPutStr clientHdl "Take a nick name : "
-  nick <- cleanString <$> hGetLine clientHdl
-  let uId  = nickToUserId nick
-      user = User uId (Just . T.pack $ nick) Waiting
+  uId  <- modifyMVar serverLastUserId getNextUserID
+  nick <- Just . T.pack . cleanString <$> hGetLine clientHdl
+  let user = User uId nick Waiting
   failedToAdd <- modifyMVar serverUsers $ \users ->
     if isNickTaken users nick
     then return (users, True)
@@ -60,15 +61,19 @@ runClient clientHdl server@Server{..} = do
   if failedToAdd
   then runClient clientHdl server
   else do atomically $ writeTChan serverChan $ PlayerJoined uId
-          hPutStrLn clientHdl $ "Hi.. " ++ nick ++ ".. Type ready when you are ready to play.. quit to quit."
+          hPutStrLn clientHdl $ "Hi.. " ++ T.unpack (fromJust nick) ++ ".. Type ready when you are ready to play.. quit to quit."
           fix $ \loop -> do ready <- cleanString <$> hGetLine clientHdl
                             case ready of
                              "ready" -> playClient uId clientHdl server
                              "quit" -> atomically $ writeTChan serverChan $ PlayerExit uId
                              _ -> loop
   where
-    nickToUserId = UserID . T.pack
-    isNickTaken users = flip M.member users . nickToUserId
+    isNickTaken users nick = any (\u -> nick == userNick u) users
+    getNextUserID uId =
+      let
+        next = UserID $ 1 + getUserID uId
+      in
+        return (next, next)
 
 cleanString :: String -> String
 cleanString = reverse . dropWhile (\c -> c == '\n' || c == '\r') . reverse
@@ -146,11 +151,11 @@ processMessages server@Server{..} game inMsgs = foldM threadGameOverEvent game i
   where threadGameOverEvent g' inMsg = case inMsg of
           PlayerJoined _           -> return game
           PlayerReady clientId     -> processPlayerReady clientId
-          PlayerTurnLeft  clientId -> processEvent server g' $ TurnLeft (userIdToPlayerNick clientId)
-          PlayerTurnRight clientId -> processEvent server g' $ TurnRight (userIdToPlayerNick clientId)
+          PlayerTurnLeft  clientId -> processEvent' g' TurnLeft clientId
+          PlayerTurnRight clientId -> processEvent' g' TurnRight clientId
           PlayerExit      clientId -> do
             modifyMVar_ serverUsers (return . M.delete clientId)
-            processEvent server g' $ PlayerQuit (userIdToPlayerNick clientId)
+            processEvent' g' PlayerQuit clientId
 
         processPlayerReady clientId = case game of
           Just game' -> return $ Just game'
@@ -166,10 +171,18 @@ processMessages server@Server{..} game inMsgs = foldM threadGameOverEvent game i
             else
               return Nothing
 
+        processEvent' game' evCons clientId = do
+          users    <- readMVar serverUsers
+          let nick  = PlayerNick . fromJust . userNick . fromJust . M.lookup clientId $ users
+              event = evCons nick
+          processEvent server game' event
+
 processEvent :: Server -> Maybe Game -> InputEvent -> IO (Maybe Game)
 processEvent Server{..} g event = do
-  let (outmsgs, game') = runGame g event
-  writeList2Chan clientsChan outmsgs
+  users               <- readMVar serverUsers
+  let (outEvs, game') = runGame g event
+      outMsgs         = outEventToOutMessage users <$> outEvs
+  writeList2Chan clientsChan outMsgs
   return game'
 
 handleIncomingMessages :: Server -> Maybe Game -> IO Game
@@ -189,32 +202,25 @@ handleIncomingMessages server@Server{..} game = do
      Just g'  -> Finished == gameStatus g'
 
 playersFromUsers :: M.Map UserID User -> M.Map PlayerNick Player
-playersFromUsers users =
-  let
-    players = M.map userToPlayer users        -- M.Map UserID Player
-  in
-    M.mapKeys userIdToPlayerNick players
+playersFromUsers = foldl userToPlayer M.empty
   where
-    userToPlayer u =
-      let nick   = userIdToPlayerNick . userId $ u
+    userToPlayer players u =
+      let nick   = PlayerNick . fromJust . userNick $ u
           player = Player nick Alive (10,10) North []
-      in player
+      in M.insert nick player players
 
-userIdToPlayerNick :: UserID -> PlayerNick
-userIdToPlayerNick = PlayerNick . T.unpack . getUserID
-
-runGame :: Maybe Game -> InputEvent -> ([OutMessage], Maybe Game)
+runGame :: Maybe Game -> InputEvent -> ([OutEvent], Maybe Game)
 runGame game event =
   case game of
     Nothing -> ([], Nothing)
-    Just g  -> (\(es, g') -> (outEventToOutMessage <$> es, Just g')) $ Engine.runEngine Engine.gameEngine g [event]
+    Just g  -> Just <$> Engine.runEngine Engine.gameEngine g [event]
 
-outEventToOutMessage :: OutEvent -> OutMessage
-outEventToOutMessage event =
+outEventToOutMessage :: M.Map UserID User -> OutEvent -> OutMessage
+outEventToOutMessage users event =
   case event of
-    Game.PlayerMoved nick coord orien -> Server.PlayerMoved (playerNickToUserId nick) coord orien
-    Game.PlayerDied  nick coord       -> Server.PlayerDied  (playerNickToUserId nick) coord
-    Game.GameEnded   nick             -> Server.GameEnded   (fmap playerNickToUserId nick)
+    Game.PlayerMoved nick coord orien -> Server.PlayerMoved (playerNickToUserId users nick) coord orien
+    Game.PlayerDied  nick coord       -> Server.PlayerDied  (playerNickToUserId users nick) coord
+    Game.GameEnded   nick             -> Server.GameEnded   (playerNickToUserId users <$> nick)
 
-playerNickToUserId :: PlayerNick -> UserID
-playerNickToUserId = UserID . T.pack . getPlayerNick
+playerNickToUserId :: M.Map UserID User -> PlayerNick -> UserID
+playerNickToUserId users nick = fst . M.elemAt 0 . M.filter (\u -> Just nick == (PlayerNick <$> userNick u)) $ users

--- a/src/Tronkell/Server/Types.hs
+++ b/src/Tronkell/Server/Types.hs
@@ -9,6 +9,7 @@ import qualified Data.Map as M
 import qualified Data.Text as T
 
 data Server = Server { serverGameConfig :: Game.GameConfig
+                     , serverLastUserId :: MVar UserID
                      , serverUsers      :: MVar (M.Map UserID User)
                      , serverSocket     :: Socket
                      , serverChan       :: TChan InMessage
@@ -16,7 +17,7 @@ data Server = Server { serverGameConfig :: Game.GameConfig
                      , internalChan     :: Chan ServerSignals
                      }
 
-newtype UserID = UserID { getUserID :: T.Text }
+newtype UserID = UserID { getUserID :: Int }
                  deriving (Eq, Show, Ord)
 
 data User = User { userId    :: UserID

--- a/test/TestEngine.hs
+++ b/test/TestEngine.hs
@@ -10,6 +10,7 @@ import Tronkell.Game.Engine
 import qualified Data.Map as Map
 import Data.List (nub, nubBy)
 import Data.Maybe (isNothing, fromJust)
+import Data.String (fromString)
 import System.Random
 
 import Test.Hspec
@@ -36,7 +37,7 @@ instance Arbitrary GameConfig where
 
 instance Arbitrary Player where
   arbitrary = do
-    n <- PlayerNick <$> arbitrary
+    n <- PlayerNick . fromString <$> arbitrary
     x <- unBoundedInt <$> arbitrary
     y <- unBoundedInt <$> arbitrary
     o <- arbitraryBoundedEnum
@@ -51,7 +52,7 @@ areOverlappingPlayers p1 p2 =
 
 genPlayer :: GameConfig -> Gen Player
 genPlayer GameConfig{..} = do
-  nick <- PlayerNick <$> arbitrary
+  nick <- PlayerNick . fromString <$> arbitrary
   x    <- unBoundedInt <$> arbitrary `suchThat` (>= 0) `suchThat` (< BoundedInt gameWidth)
   y    <- unBoundedInt <$> arbitrary `suchThat` (>= 0) `suchThat` (< BoundedInt gameHeight)
   o    <- arbitraryBoundedEnum


### PR DESCRIPTION
UserID becomes an integer so that we can create a user before a nick is
available, and the nick becoming Data.Text is just a convenience (and
probably makes sense in terms of performance).